### PR TITLE
Fix problem when executing `rails db:migrate`

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_27_163532) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_01_27_163532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,12 +18,12 @@ ActiveRecord::Schema.define(version: 2022_01_27_163532) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: 6
-    t.datetime "remember_created_at", precision: 6
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.string "first_name"
     t.string "last_name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Installing `devise` then `simple_form` and `devise` again with `simple_form` probably changed the migration file.
I probably forgot to re-execute the `rails db:migrate` command.
This pull request should fix the modification of the `schema.rb` file when executing the `rails db:migrate` command after executing `git pull origin main`.